### PR TITLE
Fix undefined objects if prob below threshold

### DIFF
--- a/code/include/TrtNet.h
+++ b/code/include/TrtNet.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <algorithm>
 #include <fstream>
+#include <numeric>
 #include "NvInferPlugin.h"
 #include "NvCaffeParser.h"
 #include "PluginFactory.h"


### PR DESCRIPTION
Main bugfix : 
* If `cProb < IGNORE_THRESH` the object metadata (`classId` and `prob`) will be skipped and therefore undefined, resulting in correctly placed objects (`bbox` is correct) but with incorrect class.

Other minor improvements :
* Using a temporary struct might also be a little more efficient as it provides faster rw access.

* `#include <numeric>` added that prevent the compilation (std::accumulate issue) on my machine